### PR TITLE
replace std::collections::HashMap with hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ authors = ["Frank Denis <github@pureftpd.org>"]
 categories = ["algorithms", "caching"]
 edition = "2018"
 
+[features]
+nightly = ["hashbrown/nightly"]
+
 [badges]
 travis-ci = { repository = "jedisct1/rust-clockpro-cache" }
 appveyor = { repository = "jedisct1/rust-clockpro-cache" }
@@ -17,6 +20,7 @@ appveyor = { repository = "jedisct1/rust-clockpro-cache" }
 slab = "0.4"
 bitflags = "1.0"
 unsafe_unwrap = "0.1"
+hashbrown = "0.1"
 
 [dev-dependencies]
 rand = "0.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ extern crate bitflags;
 use unsafe_unwrap::UnsafeUnwrap;
 
 use crate::token_ring::{Token, TokenRing};
+use hashbrown::HashMap;
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::marker::PhantomData;
 


### PR DESCRIPTION
hashbrown is a crate that is a faster drop-in replace for stdlib HashMap.

```
$ cargo benchcmp control variable
 name                           control ns/iter  variable ns/iter  diff ns/iter   diff %  speedup
 tests::bench_composite         33,617           20,355                 -13,262  -39.45%   x 1.65
 tests::bench_composite_normal  48,655           34,510                 -14,145  -29.07%   x 1.41
 tests::bench_sequence          20,126           7,749                  -12,377  -61.50%   x 2.60

$ cargo benchcmp variable nightly
 name                           variable ns/iter  nightly ns/iter  diff ns/iter   diff %  speedup
 tests::bench_composite         20,355            18,603                 -1,752   -8.61%   x 1.09
 tests::bench_composite_normal  34,510            34,776                    266    0.77%   x 0.99
 tests::bench_sequence          7,749             6,894                    -855  -11.03%   x 1.12
```