### PR TITLE
Use Criterion, not libtest, for benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,9 @@ bitflags = "1.0"
 unsafe_unwrap = "0.1"
 
 [dev-dependencies]
+criterion = "0.2"
 rand = "0.6"
 
+[[bench]]
+name = "criterion"
+harness = false

--- a/benches/criterion.rs
+++ b/benches/criterion.rs
@@ -1,0 +1,81 @@
+#[macro_use]
+extern crate criterion;
+
+use clockpro_cache::ClockProCache;
+use criterion::{black_box, Criterion};
+use rand::distributions::{Distribution, Normal, Uniform};
+use rand::thread_rng;
+
+fn bench_sequence(c: &mut Criterion) {
+    c.bench_function("bench_sequence", |b| {
+        let mut cache: ClockProCache<u64, u64> = ClockProCache::new(68).unwrap();
+        b.iter(|| {
+            for i in 1..1000 {
+                let n = i % 100;
+                black_box(cache.insert(n, n));
+            }
+        });
+        b.iter(|| {
+            for i in 1..1000 {
+                let n = i % 100;
+                black_box(cache.get(&n));
+            }
+        });
+    });
+}
+
+fn bench_composite(c: &mut Criterion) {
+    c.bench_function("bench_composite", |b| {
+        let mut cache: ClockProCache<u64, (Vec<u8>, u64)> = ClockProCache::new(68).unwrap();
+        let mut rng = thread_rng();
+        let uniform = Uniform::new(0, 100);
+        let mut rand_iter = uniform.sample_iter(&mut rng);
+        b.iter(|| {
+            for _ in 1..1000 {
+                let n = rand_iter.next().unwrap();
+                black_box(cache.insert(n, (vec![0u8; 12], n)));
+            }
+        });
+        b.iter(|| {
+            for _ in 1..1000 {
+                let n = rand_iter.next().unwrap();
+                black_box(cache.get(&n));
+            }
+        });
+    });
+}
+
+fn bench_composite_normal(c: &mut Criterion) {
+    // The cache size is ~ 1x sigma (stddev) to retain roughly >68% of records
+    const SIGMA: f64 = 50.0 / 3.0;
+
+    c.bench_function("bench_composite_normal", |b| {
+        let mut cache: ClockProCache<u64, (Vec<u8>, u64)> =
+            ClockProCache::new(SIGMA as usize).unwrap();
+
+        // This should roughly cover all elements (within 3-sigma)
+        let mut rng = thread_rng();
+        let normal = Normal::new(50.0, SIGMA);
+        let mut rand_iter = normal.sample_iter(&mut rng).map(|x| (x as u64) % 100);
+        b.iter(|| {
+            for _ in 1..1000 {
+                let n = rand_iter.next().unwrap();
+                black_box(cache.insert(n, (vec![0u8; 12], n)));
+            }
+        });
+        b.iter(|| {
+            for _ in 1..1000 {
+                let n = rand_iter.next().unwrap();
+                black_box(cache.get(&n));
+            }
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_sequence,
+    bench_composite,
+    bench_composite_normal
+);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(test)]
-extern crate test;
-
 #[macro_use]
 extern crate bitflags;
 
@@ -448,9 +445,6 @@ mod token_ring {
 #[cfg(test)]
 mod tests {
     use super::ClockProCache;
-    use rand::distributions::{Distribution, Normal, Uniform};
-    use rand::thread_rng;
-    use test::{black_box, Bencher};
 
     #[test]
     fn test_cache() {
@@ -496,67 +490,5 @@ mod tests {
                 Some(x) => assert_eq!(x.1, i),
             }
         }
-    }
-
-    #[bench]
-    fn bench_sequence(b: &mut Bencher) {
-        let mut cache: ClockProCache<u64, u64> = ClockProCache::new(68).unwrap();
-        b.iter(|| {
-            for i in 1..1000 {
-                let n = i % 100;
-                black_box(cache.insert(n, n));
-            }
-        });
-        b.iter(|| {
-            for i in 1..1000 {
-                let n = i % 100;
-                black_box(cache.get(&n));
-            }
-        });
-    }
-
-    #[bench]
-    fn bench_composite(b: &mut Bencher) {
-        let mut cache: ClockProCache<u64, (Vec<u8>, u64)> = ClockProCache::new(68).unwrap();
-        let mut rng = thread_rng();
-        let uniform = Uniform::new(0, 100);
-        let mut rand_iter = uniform.sample_iter(&mut rng);
-        b.iter(|| {
-            for _ in 1..1000 {
-                let n = rand_iter.next().unwrap();
-                black_box(cache.insert(n, (vec![0u8; 12], n)));
-            }
-        });
-        b.iter(|| {
-            for _ in 1..1000 {
-                let n = rand_iter.next().unwrap();
-                black_box(cache.get(&n));
-            }
-        });
-    }
-
-    #[bench]
-    fn bench_composite_normal(b: &mut Bencher) {
-        // The cache size is ~ 1x sigma (stddev) to retain roughly >68% of records
-        const SIGMA: f64 = 50.0 / 3.0;
-        let mut cache: ClockProCache<u64, (Vec<u8>, u64)> =
-            ClockProCache::new(SIGMA as usize).unwrap();
-
-        // This should roughly cover all elements (within 3-sigma)
-        let mut rng = thread_rng();
-        let normal = Normal::new(50.0, SIGMA);
-        let mut rand_iter = normal.sample_iter(&mut rng).map(|x| (x as u64) % 100);
-        b.iter(|| {
-            for _ in 1..1000 {
-                let n = rand_iter.next().unwrap();
-                black_box(cache.insert(n, (vec![0u8; 12], n)));
-            }
-        });
-        b.iter(|| {
-            for _ in 1..1000 {
-                let n = rand_iter.next().unwrap();
-                black_box(cache.get(&n));
-            }
-        });
     }
 }


### PR DESCRIPTION
This patch replaces the usage of the crate `test` ("libtest") for
benchmarking, which requires the nightly-only `test` feature, with the
crate `criterion` ("Criterion"), as suggested by @jedisct1, which
works on stable Rust.

As the `test` feature was the only nightly Rust feature used by
`clockpro_cache`, this patch enables `clockpro_cache` to work on
stable Rust, as it had at version 0.1.6.

I have tested that the Criterion-based benchmark introduced by this
patch does appear to work; however, I am unfamiliar with nightly Rust
and would not be able to tell whether any significant differences
exist between the benchmarking provided by Criterion and that provided
by libtest.

GitHub: Resolve jedisct1/rust-clockpro-cache#5