### PR TITLE
Add documentation, additional tests, and make Nodes accessible w/o unwrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ appveyor = { repository = "jedisct1/rust-clockpro-cache" }
 [dependencies]
 slab = "0.4"
 bitflags = "2.0"
-unsafe_unwrap = "0.1"
 
 [dev-dependencies]
 criterion = "0.4"


### PR DESCRIPTION
I've split this PR into three commits:

- 15ffa38 makes the key an `Option` so that the `slab` nodes can be initialized as `EMPTY`, and make it possible to access the nodes without unwrapping them
- 13be446 adds some additional tests to increase the coverage reported by `cargo tarpaulin`
- aef9ca1 adds documentation for things covered by `cargo doc`